### PR TITLE
fix issue 25: Need to Specify Modules Version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,12 @@ classifiers = [
     "Framework :: Flask"
 ]
 dependencies = [
-    "flask",
-    "eventlet",
-    "sqlalchemy",
-    "flask-sqlalchemy",
+    "flask==2.1.3",
+    "eventlet==0.33.1",
+    "sqlalchemy==1.4.39",
+    "flask-sqlalchemy==2.5.1",
+    "Werkzeug==2.2.0",
+    "dnspython==2.2.1",
     "flask-compress",
     "toml"
 ]


### PR DESCRIPTION
Currently when trying to install the BOFS, as there are no specific module versions, some errors will occur as the latest version of modules has changed some attributes, like the errors I encountered below:
`cannot import name 'url_quote' from "'werkzeug.urls'"`
`module 'dns.rdtypes' has no attribute 'ANY'`
`cannot import name '_app_ctx_stack' from 'flask. globals`

I found this by specifying the following module versions in the dependencies of pyproject.toml could solve this problem:
```
"flask==2.1.3",
"eventlet==0.33.1",
"sqlalchemy==1.4.39",
"flask-sqlalchemy==2.5.1",
"Werkzeug==2.2.0",
"dnspython==2.2.1",
```